### PR TITLE
Fix vtable error

### DIFF
--- a/lib/Core/Foundation/Feature.hpp
+++ b/lib/Core/Foundation/Feature.hpp
@@ -45,7 +45,7 @@ protected:
         {
             if (--m_instance.m_deferChain == 0)
             {
-                reinterpret_cast<Feature&>(m_instance).OnInitialize();
+                static_cast<Feature&>(m_instance).OnInitialize();
             }
         }
 


### PR DESCRIPTION
This cast doesn't take into account multiple inheritance, with static_cast there is a correct offset of the vtable.