### PR TITLE
feat: bind main colors in popups.

### DIFF
--- a/scripts/UI/Popups/InGamePopup.reds
+++ b/scripts/UI/Popups/InGamePopup.reds
@@ -30,7 +30,8 @@ public abstract class InGamePopup extends CustomPopup {
         vignette.SetAtlasResource(r"base\\gameplay\\gui\\widgets\\notifications\\vignette.inkatlas");
         vignette.SetTexturePart(n"vignette_1");
         vignette.SetNineSliceScale(true);
-        vignette.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        vignette.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        vignette.BindProperty(n"tintColor", n"MainColors.Red");
         vignette.SetSize(32.0, 32.0);
         vignette.SetAnchor(inkEAnchor.CenterFillHorizontaly);
         vignette.SetAnchorPoint(new Vector2(0.5, 0.5));

--- a/scripts/UI/Popups/InGamePopupFooter.reds
+++ b/scripts/UI/Popups/InGamePopupFooter.reds
@@ -24,7 +24,8 @@ public class InGamePopupFooter extends inkCustomController {
         line.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         line.SetAnchorPoint(new Vector2(0.5, 0.5));
         line.SetOpacity(0.133);
-        line.SetTintColor(ThemeColors.Bittersweet());
+        line.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        line.BindProperty(n"tintColor", n"MainColors.Red");
         line.SetSize(new Vector2(1170.0, 2.0));
         line.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         line.Reparent(footer);
@@ -40,7 +41,8 @@ public class InGamePopupFooter extends inkCustomController {
         fluffIcon.SetAnchor(inkEAnchor.BottomLeft);
         fluffIcon.SetAnchorPoint(new Vector2(0.0, 1.0));
         fluffIcon.SetOpacity(0.217);
-        fluffIcon.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        fluffIcon.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fluffIcon.BindProperty(n"tintColor", n"MainColors.Red");
         fluffIcon.SetSize(new Vector2(32.0, 32.0));
         fluffIcon.Reparent(footer);
 
@@ -53,7 +55,8 @@ public class InGamePopupFooter extends inkCustomController {
         fluffText.SetFitToContent(true);
         fluffText.SetMargin(new inkMargin(135.0, 0.0, 0.0, 75.0));
         fluffText.SetAnchor(inkEAnchor.BottomLeft);
-        fluffText.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        fluffText.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fluffText.BindProperty(n"tintColor", n"MainColors.Red");
         fluffText.SetSize(new Vector2(100.0, 32.0));
         fluffText.Reparent(footer);
 

--- a/scripts/UI/Popups/InGamePopupHeader.reds
+++ b/scripts/UI/Popups/InGamePopupHeader.reds
@@ -31,7 +31,8 @@ public class InGamePopupHeader extends inkCustomController {
         bg.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         bg.SetAnchorPoint(new Vector2(1.0, 1.0));
         bg.SetOpacity(0.61);
-        bg.SetTintColor(ThemeColors.BlackPearl());
+        bg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bg.BindProperty(n"tintColor", n"MainColors.Fullscreen_PrimaryBackgroundDarkest");
         bg.Reparent(bar);
 
         let bgr: ref<inkImage> = new inkImage();
@@ -42,7 +43,8 @@ public class InGamePopupHeader extends inkCustomController {
         bgr.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         bgr.SetAnchorPoint(new Vector2(1.0, 1.0));
         bgr.SetOpacity(0.07);
-        bgr.SetTintColor(ThemeColors.Bordeaux());
+        bgr.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bgr.BindProperty(n"tintColor", n"MainColors.PanelDarkRed");
         bgr.SetRenderTransformPivot(new Vector2(1.0, 1.0));
         bgr.Reparent(bar);
 
@@ -54,7 +56,8 @@ public class InGamePopupHeader extends inkCustomController {
         frame.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         frame.SetAnchorPoint(new Vector2(1.0, 1.0));
         frame.SetOpacity(0.217);
-        frame.SetTintColor(ThemeColors.Bittersweet());
+        frame.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        frame.BindProperty(n"tintColor", n"MainColors.Red");
         frame.SetRenderTransformPivot(new Vector2(1.0, 1.0));
         frame.Reparent(bar);
 
@@ -68,7 +71,8 @@ public class InGamePopupHeader extends inkCustomController {
         bracketBg.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         bracketBg.SetAnchorPoint(new Vector2(1.0, 1.0));
         bracketBg.SetOpacity(0.61);
-        bracketBg.SetTintColor(ThemeColors.BlackPearl());
+        bracketBg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bracketBg.BindProperty(n"tintColor", n"MainColors.Fullscreen_PrimaryBackgroundDarkest");
         bracketBg.SetRenderTransformPivot(new Vector2(1.0, 1.0));
         bracketBg.Reparent(header);
 
@@ -82,7 +86,8 @@ public class InGamePopupHeader extends inkCustomController {
         bracketBgr.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         bracketBgr.SetAnchorPoint(new Vector2(1.0, 1.0));
         bracketBgr.SetOpacity(0.217);
-        bracketBgr.SetTintColor(ThemeColors.Bittersweet());
+        bracketBgr.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bracketBgr.BindProperty(n"tintColor", n"MainColors.Red");
         bracketBgr.Reparent(header);
 
         let bracketFg: ref<inkImage> = new inkImage();
@@ -95,7 +100,8 @@ public class InGamePopupHeader extends inkCustomController {
         bracketFg.SetAnchor(inkEAnchor.BottomFillHorizontaly);
         bracketFg.SetAnchorPoint(new Vector2(1.0, 1.0));
         bracketFg.SetOpacity(0.217);
-        bracketFg.SetTintColor(ThemeColors.Bittersweet());
+        bracketFg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bracketFg.BindProperty(n"tintColor", n"MainColors.Red");
         bracketFg.Reparent(header);
 
         let title: ref<inkText> = new inkText();
@@ -108,7 +114,8 @@ public class InGamePopupHeader extends inkCustomController {
         title.SetMargin(new inkMargin(48.0, 8.0, 200.0, 6.0));
         title.SetHAlign(inkEHorizontalAlign.Left);
         title.SetVAlign(inkEVerticalAlign.Center);
-        title.SetTintColor(ThemeColors.ElectricBlue());
+        title.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        title.BindProperty(n"tintColor", n"MainColors.Blue");
         title.Reparent(header);
 
         let fluffTextR: ref<inkText> = new inkText();
@@ -122,7 +129,8 @@ public class InGamePopupHeader extends inkCustomController {
         fluffTextR.SetMargin(new inkMargin(0.0, -30.0, 0.0, 0.0));
         fluffTextR.SetHAlign(inkEHorizontalAlign.Right);
         fluffTextR.SetAnchor(inkEAnchor.TopRight);
-        fluffTextR.SetTintColor(ThemeColors.Bittersweet());
+        fluffTextR.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fluffTextR.BindProperty(n"tintColor", n"MainColors.Red");
         fluffTextR.SetRenderTransformPivot(new Vector2(1.0, 0.5));
         fluffTextR.Reparent(header);
 
@@ -137,7 +145,8 @@ public class InGamePopupHeader extends inkCustomController {
         fluffTextL.SetMargin(new inkMargin(0.0, -30.0, 0.0, 0.0));
         fluffTextL.SetHAlign(inkEHorizontalAlign.Left);
         fluffTextL.SetAnchor(inkEAnchor.TopRight);
-        fluffTextL.SetTintColor(ThemeColors.Bittersweet());
+        fluffTextL.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fluffTextL.BindProperty(n"tintColor", n"MainColors.Red");
         fluffTextL.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         fluffTextL.Reparent(header);
 

--- a/scripts/UI/Popups/InMenuPopup.reds
+++ b/scripts/UI/Popups/InMenuPopup.reds
@@ -22,7 +22,8 @@ public abstract class InMenuPopup extends CustomPopup {
         fader.SetName(n"fader");
         fader.SetAnchor(inkEAnchor.Fill);
         fader.SetOpacity(0.7);
-        fader.SetTintColor(new HDRColor(0.027451, 0.031373, 0.039216, 1.0));
+        fader.SetStyle(r"base\\gameplay\\gui\\common\\dialogs_popups.inkstyle");
+        fader.BindProperty(n"tintColor", n"Popup.faderColor");
         fader.SetSize(new Vector2(64.0, 64.0));
         fader.Reparent(this.GetRootCompoundWidget());
 
@@ -35,7 +36,8 @@ public abstract class InMenuPopup extends CustomPopup {
         bg1.SetVAlign(inkEVerticalAlign.Center);
         bg1.SetAnchor(inkEAnchor.Fill);
         bg1.SetAnchorPoint(new Vector2(0.5, 0.0));
-        bg1.SetTintColor(new HDRColor(0.262745, 0.086275, 0.094118, 1.0));
+        bg1.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bg1.BindProperty(n"tintColor", n"MainColors.PanelDarkRed");
         bg1.SetSize(new Vector2(32.0, 32.0));
         bg1.Reparent(this.GetRootCompoundWidget());
 
@@ -48,7 +50,8 @@ public abstract class InMenuPopup extends CustomPopup {
         shadow.SetVAlign(inkEVerticalAlign.Center);
         shadow.SetAnchor(inkEAnchor.TopCenter);
         shadow.SetAnchorPoint(new Vector2(0.5, 0.5));
-        shadow.SetTintColor(new HDRColor(0.027451, 0.031373, 0.039216, 1.0));
+        shadow.SetStyle(r"base\\gameplay\\gui\\common\\dialogs_popups.inkstyle");
+        shadow.BindProperty(n"tintColor", n"Popup.shadowColor");
         shadow.SetSize(new Vector2(2500.0, 1200.0));
         shadow.Reparent(this.GetRootCompoundWidget());
     }

--- a/scripts/UI/Popups/InMenuPopupContent.reds
+++ b/scripts/UI/Popups/InMenuPopupContent.reds
@@ -49,7 +49,8 @@ public class InMenuPopupContent extends inkCustomController {
         sidePartFg.SetAnchor(inkEAnchor.Fill);
         sidePartFg.SetAnchorPoint(new Vector2(1.0, 0.5));
         sidePartFg.SetOpacity(0.5);
-        sidePartFg.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        sidePartFg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        sidePartFg.BindProperty(n"tintColor", n"MainColors.Red");
         sidePartFg.SetSize(new Vector2(40.0, 32.0));
         sidePartFg.Reparent(left);
 
@@ -64,7 +65,8 @@ public class InMenuPopupContent extends inkCustomController {
         sidePartBg.SetAnchor(inkEAnchor.Fill);
         sidePartBg.SetAnchorPoint(new Vector2(1.0, 0.5));
         sidePartBg.SetOpacity(0.5);
-        sidePartBg.SetTintColor(new HDRColor(0.682353, 0.231373, 0.211765, 1.0));
+        sidePartBg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        sidePartBg.BindProperty(n"tintColor", n"MainColors.MildRed");
         sidePartBg.SetSize(new Vector2(40.0, 30.0));
         sidePartBg.Reparent(left);
 
@@ -78,7 +80,8 @@ public class InMenuPopupContent extends inkCustomController {
         sidePartAccent.SetAnchor(inkEAnchor.CenterLeft);
         sidePartAccent.SetAnchorPoint(new Vector2(0.0, 0.5));
         sidePartAccent.SetOpacity(0.2);
-        sidePartAccent.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        sidePartAccent.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        sidePartAccent.BindProperty(n"tintColor", n"MainColors.Red");
         sidePartAccent.SetSize(new Vector2(28.0, 8.0));
         sidePartAccent.SetRotation(180.0);
         sidePartAccent.Reparent(left);
@@ -100,7 +103,8 @@ public class InMenuPopupContent extends inkCustomController {
         accentBg.SetVAlign(inkEVerticalAlign.Center);
         accentBg.SetAnchorPoint(new Vector2(0.5, 0.5));
         accentBg.SetOpacity(0.05);
-        accentBg.SetTintColor(new HDRColor(0.682353, 0.231373, 0.211765, 1.0));
+        accentBg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        accentBg.BindProperty(n"tintColor", n"MainColors.MildRed");
         accentBg.SetSize(new Vector2(10.0, 160.0));
         accentBg.SetRenderTransformPivot(new Vector2(0.0, 0.0));
         accentBg.Reparent(right);
@@ -114,7 +118,8 @@ public class InMenuPopupContent extends inkCustomController {
         accentFg.SetHAlign(inkEHorizontalAlign.Right);
         accentFg.SetVAlign(inkEVerticalAlign.Center);
         accentFg.SetAnchorPoint(new Vector2(0.5, 0.5));
-        accentFg.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        accentFg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        accentFg.BindProperty(n"tintColor", n"MainColors.Red");
         accentFg.SetSize(new Vector2(10.0, 160.0));
         accentFg.SetRenderTransformPivot(new Vector2(0.0, 0.0));
         accentFg.Reparent(right);
@@ -131,7 +136,8 @@ public class InMenuPopupContent extends inkCustomController {
         protocol.SetVAlign(inkEVerticalAlign.Top);
         protocol.SetAnchorPoint(new Vector2(0.5, 0.5));
         protocol.SetOpacity(0.3);
-        protocol.SetTintColor(new HDRColor(0.682353, 0.231373, 0.211765, 1.0));
+        protocol.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        protocol.BindProperty(n"tintColor", n"MainColors.MildRed");
         protocol.SetSize(new Vector2(32.0, 32.0));
         protocol.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         protocol.SetScale(new Vector2(0.3, 0.3));
@@ -146,7 +152,8 @@ public class InMenuPopupContent extends inkCustomController {
         bg.SetFitToContent(true);
         bg.SetAnchor(inkEAnchor.Fill);
         bg.SetAnchorPoint(new Vector2(0.5, 0.5));
-        bg.SetTintColor(new HDRColor(0.054902, 0.054902, 0.090196, 1.0));
+        bg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        bg.BindProperty(n"tintColor", n"MainColors.Fullscreen_PrimaryBackgroundDarkest");
         bg.SetSize(new Vector2(32.0, 32.0));
         bg.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         bg.Reparent(right);
@@ -162,7 +169,8 @@ public class InMenuPopupContent extends inkCustomController {
         fg.SetAnchor(inkEAnchor.Fill);
         fg.SetAnchorPoint(new Vector2(0.5, 0.5));
         fg.SetOpacity(0.1);
-        fg.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        fg.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fg.BindProperty(n"tintColor", n"MainColors.Red");
         fg.SetSize(new Vector2(32.0, 32.0));
         fg.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         fg.Reparent(right);
@@ -178,7 +186,8 @@ public class InMenuPopupContent extends inkCustomController {
         fluffText1.SetAnchor(inkEAnchor.BottomLeft);
         fluffText1.SetAnchorPoint(new Vector2(0.5, 0.5));
         fluffText1.SetOpacity(0.3);
-        fluffText1.SetTintColor(new HDRColor(0.682353, 0.231373, 0.211765, 1.0));
+        fluffText1.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        fluffText1.BindProperty(n"tintColor", n"MainColors.MildRed");
         fluffText1.SetSize(new Vector2(30.0, 30.0));
         fluffText1.Reparent(right);
 
@@ -201,7 +210,8 @@ public class InMenuPopupContent extends inkCustomController {
         icon.SetMargin(new inkMargin(0.0, 10.0, 0.0, 0.0));
         icon.SetHAlign(inkEHorizontalAlign.Center);
         icon.SetVAlign(inkEVerticalAlign.Center);
-        icon.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        icon.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        icon.BindProperty(n"tintColor", n"MainColors.Red");
         icon.SetSize(new Vector2(74.0, 64.0));
         icon.SetRenderTransformPivot(new Vector2(0.0, 0.0));
         icon.SetScale(new Vector2(0.5, 0.5));
@@ -222,7 +232,8 @@ public class InMenuPopupContent extends inkCustomController {
         line.SetVAlign(inkEVerticalAlign.Top);
         line.SetAnchor(inkEAnchor.TopFillHorizontaly);
         line.SetOpacity(0.1);
-        line.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        line.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        line.BindProperty(n"tintColor", n"MainColors.Red");
         line.SetSize(new Vector2(3.0, 84.0));
         line.SetRenderTransformPivot(new Vector2(0.0, 0.5));
         line.Reparent(inkVerticalPanelWidget18);
@@ -239,7 +250,8 @@ public class InMenuPopupContent extends inkCustomController {
         title.SetMargin(new inkMargin(66.0, 20.0, 0.0, -30.0));
         title.SetVAlign(inkEVerticalAlign.Top);
         title.SetOpacity(1.0);
-        title.SetTintColor(new HDRColor(1.1761, 0.3809, 0.3476, 1.0));
+        title.SetStyle(r"base\\gameplay\\gui\\common\\main_colors.inkstyle");
+        title.BindProperty(n"tintColor", n"MainColors.Red");
         title.SetSize(new Vector2(100.0, 32.0));
         title.Reparent(inkVerticalPanelWidget18);
 

--- a/scripts/UI/Styles/ThemeColors.reds
+++ b/scripts/UI/Styles/ThemeColors.reds
@@ -2,7 +2,9 @@
 // Codeware.UI.ThemeColors
 // -----------------------------------------------------------------------------
 //
-// - Reference for base colors (should be replaced by ThemePicker)
+// NOTE: reference for base colors (should be replaced by ThemePicker /
+// StylePicker). You should use BindProperty and main_colors.inkstyle to use
+// game's engine colors when possible.
 //
 
 module Codeware.UI


### PR DESCRIPTION
Use `SetStyle` and `BindProperty` to define colors in `InGamePopup` and `InMenuPopup`. Make popups compatible with mods like HUD Painter.
Changed comment in `ThemeColors` to deprecate the class in favor of `BindProperty` feature.