### PR TITLE
fix: fix MULTIPLE_MATCHING_OVERLOADS

### DIFF
--- a/scripts/UI/Popups/CustomPopup.reds
+++ b/scripts/UI/Popups/CustomPopup.reds
@@ -115,7 +115,7 @@ public abstract class CustomPopup extends inkCustomController {
 
     protected cb func OnHidden() {
         this.ResetNotificationData();
-        this.SetGameController(null);
+        this.SetGameController(null as inkGameController);
         this.SetRootWidget(null);
     }
 


### PR DESCRIPTION
Fixes a compilation error in redscript 1

```
[ERROR - 2025-08-17T14:52:42Z] [MULTIPLE_MATCHING_OVERLOADS] At D:\win\Cyberpunk 2077\r6\scripts\r4\Codeware\Scripts\Codeware.UI.reds:1144:9
        this.SetGameController(null);
        ^^^^^^^^^^^^^^^^^^^^^^
multiple overloads match the types of the provided arguments:
  func SetGameController(gameController: inkGameController) -> Void
  func SetGameController(parentController: Codeware.UI.inkCustomController) -> Void
```