### PR TITLE
Add function to set community phase

### DIFF
--- a/scripts/World/WorldStateSystem.reds
+++ b/scripts/World/WorldStateSystem.reds
@@ -5,6 +5,7 @@ public native class WorldStateSystem extends IGameSystem {
 
     public native func ActivateCommunity(community: NodeRef, opt entry: CName)
     public native func DeactivateCommunity(community: NodeRef, opt entry: CName)
+    public native func SetCommunityPhase(community: NodeRef, entry: CName, phase: CName)
 
     public native func ToggleNode(node: NodeRef, state: Bool)
     public native func ToggleVariant(ref: NodeRef, name: CName, state: Bool)

--- a/src/App/World/WorldStateSystem.cpp
+++ b/src/App/World/WorldStateSystem.cpp
@@ -54,6 +54,17 @@ void App::WorldStateSystem::DeactivateCommunity(Red::NodeRef aNodeRef, Red::Opti
     Raw::CommunitySystem::Update(m_communitySystem, true);
 }
 
+void App::WorldStateSystem::SetCommunityPhase(Red::NodeRef aNodeRef, Red::CName aEntryName, Red::CName aPhaseName)
+{
+    auto communityID = Red::ResolveNodeRef(aNodeRef);
+
+    if (!communityID)
+        return;
+
+    Raw::CommunitySystem::SetCommunityPhase(m_communitySystem, communityID, aEntryName, aPhaseName);
+    Raw::CommunitySystem::Update(m_communitySystem, true);
+}
+
 void App::WorldStateSystem::ToggleNode(Red::NodeRef aNodeRef, bool aState)
 {
     auto resetNodeType = Red::MakeHandle<Red::questShowWorldNode_NodeType>();

--- a/src/App/World/WorldStateSystem.hpp
+++ b/src/App/World/WorldStateSystem.hpp
@@ -14,6 +14,7 @@ public:
 
     void ActivateCommunity(Red::NodeRef aNodeRef, Red::Optional<Red::CName> aEntryName);
     void DeactivateCommunity(Red::NodeRef aNodeRef, Red::Optional<Red::CName> aEntryName);
+    void SetCommunityPhase(Red::NodeRef aNodeRef, Red::CName aEntryName, Red::CName aPhaseName);
 
     void ToggleNode(Red::NodeRef aNodeRef, bool aState);
     void ToggleVariant(Red::NodeRef aNodeRef, Red::CName aVariant, bool aState);
@@ -41,6 +42,7 @@ RTTI_DEFINE_CLASS(App::WorldStateSystem, {
     RTTI_METHOD(GetStreamingWorld);
     RTTI_METHOD(ActivateCommunity);
     RTTI_METHOD(DeactivateCommunity);
+    RTTI_METHOD(SetCommunityPhase);
     RTTI_METHOD(ToggleNode);
     RTTI_METHOD(ToggleVariant);
 });


### PR DESCRIPTION
Adds `SetCommunityPhase()` to `WorldStateSystem` which allows setting community phase 

Tested it and it seems to succesfully cycle phase on an activated community
