### PR TITLE
Extensions for raycast TraceResult and worldCollisionNodeInstance

### DIFF
--- a/scripts/Base/Imports/worldCollisionNodeInstance.reds
+++ b/scripts/Base/Imports/worldCollisionNodeInstance.reds
@@ -1,1 +1,8 @@
-public native class worldCollisionNodeInstance extends worldINodeInstance {}
+public native class worldCollisionNodeInstance extends worldINodeInstance {
+  public native func GetPrimaryPhysicsProxyID() -> Uint32
+  public native func GetOverflowPhysicsProxyID() -> Uint32
+  public native func HasOverflowPhysicsProxy() -> Bool
+  public native func GetCollisionActorCount() -> Int32
+  public native func GetCollisionSplitIndex() -> Int32
+  public native func ResolveActorIndex(hitProxyID: Uint32, localActorIndex: Uint32) -> Int32
+}

--- a/scripts/Physics/TraceResult.reds
+++ b/scripts/Physics/TraceResult.reds
@@ -1,4 +1,13 @@
 @addMethod(TraceResult)
+public final static native func GetProxyID(self: script_ref<TraceResult>) -> Uint32
+
+@addMethod(TraceResult)
+public final static native func GetActorIndex(self: script_ref<TraceResult>) -> Uint32
+
+@addMethod(TraceResult)
+public final static native func GetShapeIndex(self: script_ref<TraceResult>) -> Int32
+
+@addMethod(TraceResult)
 public final static native func GetHitObject(self: script_ref<TraceResult>) -> ref<ISerializable>
 
 @addMethod(TraceResult)

--- a/src/App/Physics/TraceResultEx.hpp
+++ b/src/App/Physics/TraceResultEx.hpp
@@ -6,6 +6,21 @@ namespace App
 {
 struct TraceResultEx : Red::TraceResult
 {
+    uint32_t GetProxyID()
+    {
+        return Raw::PhysicsTraceResult::ResultID::Ref(this);
+    }
+
+    uint32_t GetActorIndex()
+    {
+        return Raw::PhysicsTraceResult::ActorIndex::Ref(this);
+    }
+
+    int32_t GetShapeIndex()
+    {
+        return Raw::PhysicsTraceResult::ShapeIndex::Ref(this);
+    }
+
     Red::Handle<Red::ISerializable> GetHitObject()
     {
         auto& resultID = Raw::PhysicsTraceResult::ResultID::Ref(this);
@@ -45,6 +60,9 @@ struct TraceResultEx : Red::TraceResult
 }
 
 RTTI_EXPAND_CLASS(Red::TraceResult, App::TraceResultEx, {
+    RTTI_METHOD(GetProxyID);
+    RTTI_METHOD(GetActorIndex);
+    RTTI_METHOD(GetShapeIndex);
     RTTI_METHOD(GetHitObject);
     RTTI_METHOD(GetHitEntity);
 });

--- a/src/App/World/CollisionNodeInstanceEx.hpp
+++ b/src/App/World/CollisionNodeInstanceEx.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "Red/WorldNode.hpp"
+#include <RED4ext/Scripting/Natives/Generated/world/CollisionNode.hpp>
+#include <RED4ext/Scripting/Natives/Generated/world/CollisionNodeInstance.hpp>
+
+namespace App
+{
+struct CollisionNodeInstanceEx : Red::worldCollisionNodeInstance
+{
+    [[nodiscard]] uint32_t GetPrimaryPhysicsProxyID() const
+    {
+        return Raw::WorldCollisionNodeInstance::PrimaryProxyID::Ref(this);
+    }
+
+    [[nodiscard]] uint32_t GetOverflowPhysicsProxyID() const
+    {
+        return Raw::WorldCollisionNodeInstance::OverflowProxyID::Ref(this);
+    }
+
+    [[nodiscard]] bool HasOverflowPhysicsProxy() const
+    {
+        return GetOverflowPhysicsProxyID() != 0;
+    }
+
+    [[nodiscard]] int32_t GetCollisionActorCount() const
+    {
+        auto node = Raw::WorldNodeInstance::Node::Ref(this);
+        if (!node)
+            return 0;
+
+        if (auto collisionNode = Red::Cast<Red::worldCollisionNode>(node))
+            return static_cast<int32_t>(collisionNode->numActors);
+
+        return 0;
+    }
+
+    [[nodiscard]] int32_t GetCollisionSplitIndex() const
+    {
+        const int32_t count = GetCollisionActorCount();
+        return HasOverflowPhysicsProxy() ? count / 2 : count;
+    }
+
+    [[nodiscard]] int32_t ResolveActorIndex(uint32_t aHitProxyID, uint32_t aLocalActorIndex) const
+    {
+        if (aHitProxyID == GetPrimaryPhysicsProxyID())
+            return static_cast<int32_t>(aLocalActorIndex);
+
+        if (HasOverflowPhysicsProxy() && aHitProxyID == GetOverflowPhysicsProxyID())
+            return GetCollisionSplitIndex() + static_cast<int32_t>(aLocalActorIndex);
+
+        return -1;
+    }
+};
+}
+
+RTTI_EXPAND_CLASS(Red::worldCollisionNodeInstance, App::CollisionNodeInstanceEx, {
+    RTTI_METHOD(GetPrimaryPhysicsProxyID);
+    RTTI_METHOD(GetOverflowPhysicsProxyID);
+    RTTI_METHOD(HasOverflowPhysicsProxy);
+    RTTI_METHOD(GetCollisionActorCount);
+    RTTI_METHOD(GetCollisionSplitIndex);
+    RTTI_METHOD(ResolveActorIndex);
+});

--- a/src/Red/Physics.hpp
+++ b/src/Red/Physics.hpp
@@ -3,6 +3,8 @@
 namespace Raw::PhysicsTraceResult
 {
 using ResultID = Core::OffsetPtr<0x48, uint32_t>;
+using ActorIndex = Core::OffsetPtr<0x4C, uint32_t>;
+using ShapeIndex = Core::OffsetPtr<0x50, int32_t>;
 
 constexpr auto GetHitObject = Core::RawFunc<
     /* addr = */ Red::AddressLib::PhysicsTraceResult_GetHitObject,

--- a/src/Red/WorldNode.hpp
+++ b/src/Red/WorldNode.hpp
@@ -53,3 +53,9 @@ namespace Raw::WorldEntityNodeInstance
 {
 using Entity = Core::OffsetPtr<0xA0, Red::Handle<Red::Entity>>;
 }
+
+namespace Raw::WorldCollisionNodeInstance
+{
+using PrimaryProxyID = Core::OffsetPtr<0x90, uint32_t>;
+using OverflowProxyID = Core::OffsetPtr<0x94, uint32_t>;
+}

--- a/src/rtti.cpp
+++ b/src/rtti.cpp
@@ -71,6 +71,7 @@
 #include "App/Utils/Number.hpp"
 #include "App/Utils/String.hpp"
 #include "App/Utils/TweakDBID.hpp"
+#include "App/World/CollisionNodeInstanceEx.hpp"
 #include "App/World/DynamicEntityEvent.hpp"
 #include "App/World/DynamicEntitySpec.hpp"
 #include "App/World/DynamicEntityState.hpp"


### PR DESCRIPTION
## Changes
- New TraceResult methods to get hit collision node: 
  - ``actor index`` - local to collision node proxy
  - ``shape index``
  - ``proxy id`` - id of the proxy. In runtime game splits collision node actors in 2 proxies if there more than 64 actors
 - New methods for worldCollisionNodeInstance to get:
   -  ``primary proxy id``
   - ``overflow proxy id``
   - ``actor index`` - index of actor that matches index of actor definition inside ``.streaminsector`` file